### PR TITLE
fix(panel): calendar popup can never be closed on current Omarchy

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -357,7 +357,9 @@ Panel {
   // Summoning by hotkey moves no pointer, so a hover the bar was still
   // holding must not keep the center indicators revealed behind the panel.
   function setCenterHoverRevealSuppressed(value) {
-    if (root.bar && "centerHoverRevealSuppressed" in root.bar)
+    if (root.bar && typeof root.bar.setCenterHoverRevealSuppressed === "function")
+      root.bar.setCenterHoverRevealSuppressed(value)
+    else if (root.bar && "centerHoverRevealSuppressed" in root.bar)
       root.bar.centerHoverRevealSuppressed = value
   }
 


### PR DESCRIPTION
## Symptom

Once the calendar popup is open it cannot be dismissed at all — clicking the clock again, clicking outside the card, and <kbd>Esc</kbd> all do nothing. The popup stays up until the shell is restarted. Opening works fine; only closing is broken.

## Root cause

`Panel.qml` writes the bar property directly:

```qml
function setCenterHoverRevealSuppressed(value) {
  if (root.bar && "centerHoverRevealSuppressed" in root.bar)
    root.bar.centerHoverRevealSuppressed = value   // throws
}
```

Omarchy hands third-party plugins a `PluginBarApi` object rather than the `Bar` itself, and there the property is read-only (`Ui/PluginBarApi.qml:26`):

```qml
property bool _centerHoverRevealSuppressed: false
readonly property bool centerHoverRevealSuppressed: _centerHoverRevealSuppressed

function setCenterHoverRevealSuppressed(value) { ... }
```

So every call logs:

```
WARN scene: .../Panel.qml[361:-1]: TypeError: Cannot assign to read-only property "centerHoverRevealSuppressed"
```

The `in` guard passes (the property exists), it just isn't writable — so the guard doesn't protect the assignment.

## Why that breaks closing specifically

Note the ordering of the two lifecycle functions:

```qml
function open()  { …; root.controller.show();  setCenterHoverRevealSuppressed(true)  }  // show() already ran
function close() { setCenterHoverRevealSuppressed(false); …; root.controller.hide() }  // throws first
```

In `close()` the helper is the **first** statement, so the `TypeError` aborts the function before it reaches `root.controller.hide()` and the panel never leaves the open state. In `open()` it is the **last** statement, after `controller.show()`, which is why opening is unaffected. Every dismissal route funnels through the same `close()`, so the click-outside overlay, the bar button toggle and `PanelKeyCatcher`'s Escape handler all die at the same line.

## Fix

Prefer the API setter, keep the direct assignment as a fallback. This is exactly what Omarchy's own panels do — see `plugins/panels/clock/Panel.qml:121-126` and `plugins/panels/weather/Panel.qml:66-69`:

```qml
if (root.bar && typeof root.bar.setCenterHoverRevealSuppressed === "function")
  root.bar.setCenterHoverRevealSuppressed(value)
else if (root.bar && "centerHoverRevealSuppressed" in root.bar)
  root.bar.centerHoverRevealSuppressed = value
```

The fallback keeps it working on older Omarchy builds that still exposed a writable `Bar`.

## Verification

Omarchy 4.0.3-1, Quickshell 0.3.1, Arch, two outputs, top bar. Counting the popup's layer surfaces (`omarchy-keyboard-panel`, which includes the off-output dismissal twin) before and after:

| Action | Surfaces before fix | Surfaces after fix |
|---|---|---|
| `shell summon <id>` | 2 | 2 |
| `shell hide <id>` | **2** (stuck open) | **0** |
| `shell toggle` ×2 | 2 → **2** | 2 → **0** |
| `TypeError` in journal | on every open *and* close | none |

Also confirmed by hand: clicking the clock, clicking outside and <kbd>Esc</kbd> all dismiss the popup again, and the hover-reveal suppression the helper was written for now actually takes effect (it had been silently throwing on open too, so the feature never worked).

A shell restart is needed to pick this up — `rescanPlugins` alone keeps the old compiled `Panel.qml` in memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqokydiguwMxAswEbAof7D
